### PR TITLE
closes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ annotator.unassign_from_project project_title: 'bluetooth port indexing' # unass
 The `raw_datum` object can `create` a datum and `destroy_all` of them.
 
 ```ruby
-raw_datum = DalphiProfiler::Annotator.new project_title: 'bluetooth port indexing',
-                                          file: '/path/to/your/raw_datum.json'
+raw_datum = DalphiProfiler::RawDatum.new project_title: 'bluetooth port indexing',
+                                         files: ['/path/to/your/raw_datum_1.json', '/path/to/your/raw_datum_2.json']
 
 raw_datum.create # creates a raw datum with the given file for the project with the specified project title
 raw_datum.destroy_all # destroys all raw data associated to the project with the given title

--- a/profiler.rb
+++ b/profiler.rb
@@ -275,7 +275,7 @@ module DalphiProfiler
 
       page.evaluate_script '$("#raw_datum_data").removeAttr("accept")'
 
-      attach_file 'raw_datum_data', @files.map(&:path)
+      attach_file 'raw_datum_data', @files
 
       find(:css, '.btn-primary').trigger('click')
     rescue


### PR DESCRIPTION
`path` is undefined
```
attach_file 'raw_datum_data', @files.map(&:path)
```
should be replaceable by the array itself, since this already contains path strings